### PR TITLE
Add experimental Julia Genie server using PythonCall

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ docker run -it --rm --pull=always \
 > On a public network? See our [Hardened Docker Installation Guide](https://docs.all-hands.dev/usage/runtimes/docker#hardened-docker-installation)
 > to secure your deployment by restricting network binding and implementing additional security measures.
 
+### Option 3: Julia Genie Server (Experimental)
+
+We are exploring a high-performance Julia implementation of the OpenHands server using
+[Genie.jl](https://genieframework.com/) and [PythonCall.jl](https://cjdoris.github.io/PythonCall.jl/stable/).
+This experimental path boots a Genie web application that reuses existing Python business logic and
+is a starting point for progressively porting server features to Julia.
+
+```bash
+julia --project=julia_genie julia_genie/start.jl
+```
+
+The script activates the Julia environment defined in `julia_genie/Project.toml`, installs the
+required packages on the first run, and serves the health endpoints on <http://0.0.0.0:8001>. Routes
+are backed by the same Python modules as the FastAPI server, so you can run both stacks side-by-side
+while comparing behaviour and performance.
+
+See [`julia_genie/README.md`](./julia_genie/README.md) for details on extending the Genie server and
+working with PythonCall.
+
 ### Getting Started
 
 When you open the application, you'll be asked to choose an LLM provider and add an API key.

--- a/julia_genie/Project.toml
+++ b/julia_genie/Project.toml
@@ -1,0 +1,13 @@
+name = "PrayerHandsGenie"
+uuid = "fca8f8a0-63e9-4f9d-9da9-14318e403d30"
+authors = ["PrayerHands Contributors"]
+version = "0.1.0"
+
+[deps]
+Genie = "c7f686f2-ff18-58e9-b06a-1f7be6675a1a"
+PythonCall = "6099a3de-390e-11e9-1c5d-532679323890"
+
+[compat]
+Genie = "5"
+PythonCall = "0.9"
+julia = "1.10"

--- a/julia_genie/README.md
+++ b/julia_genie/README.md
@@ -1,0 +1,73 @@
+# PrayerHands Genie Server
+
+This directory contains an experimental [Genie.jl](https://genieframework.com) server that mirrors the
+Python FastAPI server's health endpoints while relying on
+[PythonCall.jl](https://cjdoris.github.io/PythonCall.jl/stable/) to access existing Python
+infrastructure in the PrayerHands codebase.
+
+## Project goals
+
+- Provide a high performance Julia-based entry point that can evolve towards parity with the
+  Python FastAPI implementation.
+- Demonstrate how PythonCall.jl can be used to reuse Python services without duplicating logic.
+- Offer a foundation for progressively porting critical request paths to Julia/Genie.
+
+## Layout
+
+```
+julia_genie/
+├── Project.toml        # Julia project manifest for the Genie application
+├── README.md           # This guide
+├── src/PrayerHandsGenie.jl  # Genie module wrapping Python functionality
+└── start.jl            # Helper script that instantiates dependencies and boots the server
+```
+
+The Julia module defines three routes (`/alive`, `/health`, and `/server_info`) that call into the
+existing Python `openhands.runtime.utils.system_stats` module. The `server_info` endpoint therefore
+returns exactly the same payload as the Python FastAPI version but is served from Genie.
+
+## Prerequisites
+
+1. Julia 1.10 or newer installed locally.
+2. A working Python environment for PrayerHands (the same one used to run the FastAPI server).
+
+The Julia server automatically adds the PrayerHands repository root to Python's `sys.path`, so you
+should execute Julia from the repository root to ensure Python modules can be located.
+
+## Running the server
+
+From the root of the repository:
+
+```bash
+julia --project=julia_genie julia_genie/start.jl
+```
+
+The script activates the local Julia environment, installs dependencies on the first run, and
+exposes the Genie server on `http://0.0.0.0:8001` by default.
+
+You can override the host and port programmatically:
+
+```julia
+julia --project=julia_genie -e 'using PrayerHandsGenie; PrayerHandsGenie.start(host="127.0.0.1", port=8888)'
+```
+
+Once running, the Julia and Python servers can co-exist. This makes it easy to compare responses and
+performance characteristics while gradually porting more features to Julia.
+
+## Extending the server
+
+- Add new Genie routes inside `setup_routes()` in `src/PrayerHandsGenie.jl`.
+- Use `PythonCall.pyimport` to reuse business logic from the Python codebase until a native Julia
+  implementation is available.
+- For larger features, consider splitting Julia logic into additional modules under `src/` and
+  adding complementary integration tests written in Julia.
+
+## Troubleshooting
+
+- **Python module import errors** – verify you're running Julia from the repository root and that
+  the Python environment can import `openhands`. The server raises a descriptive error when Python
+  dependencies are missing.
+- **Port already in use** – pass a different `port` argument to `PrayerHandsGenie.start`.
+
+This setup is intentionally lightweight so that future contributions can iterate rapidly on a Julia
+Genie alternative to the existing FastAPI service.

--- a/julia_genie/src/PrayerHandsGenie.jl
+++ b/julia_genie/src/PrayerHandsGenie.jl
@@ -1,0 +1,61 @@
+module PrayerHandsGenie
+
+export start
+
+using Genie
+using Genie.Router: route, GET
+using Genie.Renderer.Json: json
+using PythonCall: Py, pycall, pyconvert, pyimport
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+const ROUTES_INITIALIZED = Ref(false)
+const SYSTEM_STATS = Ref{Union{Nothing, Py}}(nothing)
+
+function __init__()
+    ensure_python_path!()
+    SYSTEM_STATS[] = pyimport("openhands.runtime.utils.system_stats")
+end
+
+function ensure_python_path!()
+    sys = pyimport("sys")
+    path_list = sys."path"
+    has_path = pycall(path_list.__contains__, Bool, PROJECT_ROOT)
+    if !has_path
+        path_list.insert(0, PROJECT_ROOT)
+    end
+    return nothing
+end
+
+function setup_routes()
+    if ROUTES_INITIALIZED[]
+        return nothing
+    end
+
+    route("/alive", method = GET) do
+        json(Dict("status" => "ok"))
+    end
+
+    route("/health", method = GET) do
+        "OK"
+    end
+
+    route("/server_info", method = GET) do
+        stats_mod = SYSTEM_STATS[]
+        stats_mod === nothing && throw(ErrorException("Python system stats module not initialised"))
+        info = stats_mod.get_system_info()
+        converted = pyconvert(Dict{String, Any}, info)
+        json(converted)
+    end
+
+    ROUTES_INITIALIZED[] = true
+    return nothing
+end
+
+function start(; host::AbstractString = "0.0.0.0", port::Integer = 8001, async::Bool = false)
+    ensure_python_path!()
+    setup_routes()
+
+    Genie.up(host = host, port = port, async = async)
+end
+
+end # module

--- a/julia_genie/start.jl
+++ b/julia_genie/start.jl
@@ -1,0 +1,8 @@
+#!/usr/bin/env julia
+import Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
+using PrayerHandsGenie
+
+PrayerHandsGenie.start()


### PR DESCRIPTION
## Summary
- add a julia_genie project that exposes Genie routes backed by existing Python health logic via PythonCall
- provide a Julia entrypoint script and documentation for running and extending the experimental server
- document the new Julia Genie option in the main README so contributors can boot the server alongside FastAPI

## Testing
- pre-commit

------
https://chatgpt.com/codex/tasks/task_b_68de7df22b4483319d190a43bc3a4a6c